### PR TITLE
wait before checking if we are receiving

### DIFF
--- a/RFControl.cpp
+++ b/RFControl.cpp
@@ -478,6 +478,8 @@ void listenBeforeTalk()
   // listen before talk
   unsigned long waited = 0;
   if(interruptPin != -1) {
+      waited += 500;
+      hw_delayMicroseconds(500); 
     while(state > STATUS_RECORDING_0 && state != STATUS_RECORDING_END) {
       //wait till no rf message is in the air
       waited += 5;


### PR DESCRIPTION
Without waiting, most of the times the arduino would start sending
while there was still messages in the air. It seems that it had no
time to enter the STATUS_RECORDING_1 state for the second received
message.