### PR TITLE
Add switch31 for Conrad RSL remote sockets

### DIFF
--- a/arduino_functions.h
+++ b/arduino_functions.h
@@ -27,7 +27,7 @@ static inline void hw_delayMicroseconds(uint32_t time_to_wait) {
   // https://github.com/pimatic/rfcontroljs/issues/29#issuecomment-85460916
   while(time_to_wait > 16000) {
     #if defined(ESP8266)
-      delay(16)
+      delay(16);
     #else
       delayMicroseconds(16000);
     #endif

--- a/library.json
+++ b/library.json
@@ -1,0 +1,15 @@
+{
+    "name": "RFcontrol",
+    "keywords": "rf, 433mhz, arduino",
+    "description": "Arduino library for 433mhz RF sniffing and receiving.",
+    "repository":
+    {
+        "type": "git",
+        "url": "https://github.com/pimatic/RFControl.git"
+    },
+    "export": {
+      "exclude": "simulate"
+    },
+    "frameworks": "arduino",
+    "platforms": "atmelavr"
+}


### PR DESCRIPTION
I have RSL Sockets from Conrad. Unfartunaly I only ordered sockets without a remote control. 
I've found a Website where someone wrote down the codes. 
Please add this socket to the list. 
http://www.forum-raspberrypi.de/Thread-tutorial-tutorial-radio-receiver-rsl366r-ansteuerung
Thanks