### PR TITLE
Handle interrupt correctly on ESP8266

### DIFF
--- a/RFControl.cpp
+++ b/RFControl.cpp
@@ -33,7 +33,11 @@ bool data1_ready = false;
 bool data2_ready = false;
 bool skip = false;
 bool new_duration = false;
+#ifdef ICACHE_RAM_ATTR
+void ICACHE_RAM_ATTR handleInterrupt();
+#else
 void handleInterrupt();
+#endif
 
 unsigned int RFControl::getPulseLengthDivider() {
   return PULSE_LENGTH_DIVIDER;


### PR DESCRIPTION
For ESP8266 the interrupt handler must be in IRAM.
Newer Arduino versions for ESP seem to enforce this now. Marking `handleInterrupt()` with `ICACHE_RAM_ATTR` fixes this.

See https://forum.arduino.cc/index.php?topic=616264.msg4182494#msg4182494
