### PR TITLE
Fixed interrupt handling on ESP8266

### DIFF
--- a/RFControl.cpp
+++ b/RFControl.cpp
@@ -288,7 +288,11 @@ void verification(int package) {
   }
 }
 
+#if defined(ESP8266)
+void ICACHE_RAM_ATTR handleInterrupt() {
+#else
 void handleInterrupt() {
+#endif
   //hw_digitalWrite(9, HIGH);
   unsigned long currentTime = hw_micros();
   duration = (currentTime - lastTime) / PULSE_LENGTH_DIVIDER;


### PR DESCRIPTION
With ESP8266 Board support package V3.0.0 an exception is issued whenever an interrupt occurs:
```
[...]
connected...yeey :)
HTTP server started
local ip:
192.168.156.166
*WM: freeing allocated params!
pm open,type:2 0
handleReceive()
ISR not in IRAM!

User exception (panic/abort/assert)
--------------- CUT HERE FOR EXCEPTION DECODER ---------------

Abort called

>>>stack>>>
[...]
```
This is not specific to RFControl. I found a hint to fix the issue as follows:
Change
```
void handleInterrupt() {
```
to
```
void ICACHE_RAM_ATTR handleInterrupt() {
```
and added some C pre-processing to leave the code untouched for non ESP8266 targets.
